### PR TITLE
debug-log CSS tweak

### DIFF
--- a/client/src/app.ts
+++ b/client/src/app.ts
@@ -172,7 +172,8 @@ class WebRTCApp {
             this.botContainer.style.display = "none";
           }
           if ('show_debug_container' in msg && !msg.show_debug_container) {
-            this.debugLog.style.display = "none";
+            const debugLogPanel = document.getElementsByClassName("debug-panel")[0] as HTMLElement;
+            debugLogPanel.style.display = "none";
           }
         },
       },
@@ -214,7 +215,7 @@ class WebRTCApp {
     this.audioElement = document.getElementById(
       "bot-audio"
     ) as HTMLAudioElement;
-    this.debugLog = document.getElementsByClassName("debug-panel")[0] as HTMLElement;
+    this.debugLog = document.getElementById("debug-log") as HTMLElement;
     this.textChatLog = document.getElementById(
       "text-chat-log"
     ) as HTMLElement;


### PR DESCRIPTION
Fix CSS goof I introduced with previous PR

Before:
<img width="885" alt="before" src="https://github.com/user-attachments/assets/b335009c-765e-4847-986f-6592efeb51b9" />

After:
<img width="893" alt="after" src="https://github.com/user-attachments/assets/f98340c3-a1d5-4e7b-98df-6049a07bd14e" />
