### PR TITLE
Refine transport selector header layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to **Pipecat AI Prebuilt** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.1] - 2026-05-19
+
+### Changed
+
+- Moved the transport selector into the console header and updated it to use
+  the `voice-ui-kit` Select component.
+- Restored the Pipecat logo next to the header title and refined header spacing.
+
 ## [2.5.0] - 2026-04-22
 
 ### Changed

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "ISC",
       "dependencies": {
         "@pipecat-ai/client-js": "^1.8.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "main": "index.js",
   "scripts": {
     "dev": "node_modules/.bin/vite",

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,6 +1,12 @@
 import {
   ConsoleTemplate,
   FullScreenContainer,
+  Select,
+  SelectContent,
+  SelectGuide,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   ThemeProvider,
 } from "@pipecat-ai/voice-ui-kit";
 import React, { StrictMode, useState } from "react";
@@ -90,6 +96,37 @@ function getTransportProps(
   }
 }
 
+type TransportSelectProps = {
+  value: TransportType;
+  onValueChange: (value: TransportType) => void;
+};
+
+function TransportSelect({ value, onValueChange }: TransportSelectProps) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(next) => onValueChange(next as TransportType)}
+    >
+      <SelectTrigger
+        aria-label="Transport"
+        className="transport-select-trigger"
+        rounded="lg"
+        size="md"
+      >
+        <SelectGuide>Transport</SelectGuide>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {TRANSPORT_OPTIONS.map(({ value, label }) => (
+          <SelectItem key={value} value={value}>
+            {label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
 function Home() {
   const [transportType, setTransportType] =
     useState<TransportType>("smallwebrtc");
@@ -126,64 +163,27 @@ function Home() {
   return (
     <ThemeProvider>
       <FullScreenContainer className="items-stretch justify-start">
-        <div
-          style={{
-            padding: "8px 16px",
-            display: "flex",
-            alignItems: "center",
-            gap: "8px",
-            borderBottom: "1px solid var(--border)",
-            background: "var(--background)",
+        <ConsoleTemplate
+          key={transportType}
+          transportType={
+            transportType === "twilio" ? "websocket" : transportType
+          }
+          startBotParams={startBotParams}
+          transportOptions={transportOptions}
+          startBotResponseTransformer={startBotResponseTransformer}
+          noUserVideo={true}
+          logoComponent={
+            <TransportSelect
+              value={transportType}
+              onValueChange={setTransportType}
+            />
+          }
+          onClient={(client) => {
+            client.on(RTVIEvent.Connected, async () => {
+              await onClientConnected(client);
+            });
           }}
-        >
-          <label
-            htmlFor="transport-select"
-            style={{
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "var(--foreground)",
-            }}
-          >
-            Transport:
-          </label>
-          <select
-            id="transport-select"
-            value={transportType}
-            onChange={(e) => setTransportType(e.target.value as TransportType)}
-            style={{
-              padding: "4px 8px",
-              borderRadius: "6px",
-              border: "1px solid var(--border)",
-              background: "var(--background)",
-              color: "var(--foreground)",
-              fontSize: "0.875rem",
-              cursor: "pointer",
-            }}
-          >
-            {TRANSPORT_OPTIONS.map(({ value, label }) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div style={{ flex: 1, minHeight: 0 }}>
-          <ConsoleTemplate
-            key={transportType}
-            transportType={
-              transportType === "twilio" ? "websocket" : transportType
-            }
-            startBotParams={startBotParams}
-            transportOptions={transportOptions}
-            startBotResponseTransformer={startBotResponseTransformer}
-            noUserVideo={true}
-            onClient={(client) => {
-              client.on(RTVIEvent.Connected, async () => {
-                await onClientConnected(client);
-              });
-            }}
-          />
-        </div>
+        />
       </FullScreenContainer>
     </ThemeProvider>
   );

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -5,3 +5,31 @@ body {
   height: 100%;
   margin: 0;
 }
+
+.transport-select-trigger {
+  width: 190px;
+  max-width: calc(100vw - 1rem);
+}
+
+.grid:has(> .transport-select-trigger) {
+  padding-top: 12px;
+  padding-bottom: 4px;
+}
+
+@media (min-width: 640px) {
+  .grid:has(> .transport-select-trigger) > strong {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.625rem;
+  }
+
+  .grid:has(> .transport-select-trigger) > strong::before {
+    content: "";
+    width: 42px;
+    height: 24px;
+    flex: none;
+    background-color: currentColor;
+    mask: url("/pipecat-logo.svg") center / contain no-repeat;
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pipecat-ai-prebuilt"
-version = "1.0.0"
+version = "2.5.1"
 description = "A simple, ready-to-use prebuilt client supporting all Pipecat transports."
 license = { text = "BSD 2-Clause License" }
 readme = "README.md"
@@ -40,4 +40,3 @@ include = ["pipecat_ai_prebuilt*"]
 
 [tool.setuptools.package-data]
 "pipecat_ai_prebuilt" = ["client/dist/**/*"]
-

--- a/test/uv.lock
+++ b/test/uv.lock
@@ -2028,7 +2028,7 @@ webrtc = [
 
 [[package]]
 name = "pipecat-ai-prebuilt"
-version = "1.0.0"
+version = "2.5.1"
 source = { editable = "../" }
 dependencies = [
     { name = "fastapi", extra = ["all"] },

--- a/uv.lock
+++ b/uv.lock
@@ -544,7 +544,7 @@ wheels = [
 
 [[package]]
 name = "pipecat-ai-prebuilt"
-version = "2.5.0"
+version = "2.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["all"] },


### PR DESCRIPTION
Minor layout / visual change to the header UI. The motivation was to reclaim lost space in the top bar. This uses a Select component from the voice-ui-kit for polish and moves the logo to the title to reclaim vertical height.

Before:
<img width="3752" height="2788" alt="CleanShot 2026-05-19 at 09 28 08@2x" src="https://github.com/user-attachments/assets/6a9bdb8e-f793-4ec8-a555-9953e079bc34" />


After:
<img width="3752" height="2788" alt="CleanShot 2026-05-19 at 09 27 51@2x" src="https://github.com/user-attachments/assets/e661f10e-5a00-4f22-9d31-abf1e1f55a7e" />
