### PR TITLE
Support MoQ direct mode, reading the session from the URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Users should install:
 pip install pipecat-ai-prebuilt
 ```
 
+## [Unreleased]
+
+### Added
+
+- MoQ direct-mode support. A bot run with `--moq-direct` is already on the
+  relay before anyone opens the client, so there is no `/start` to ask where
+  to meet it. The client reads the session from the page URL instead —
+  `relay`, `ns`, `botId`, and `clientId`, as the Pipecat runner prints them —
+  and connects the transport straight from those, skipping the `/start` POST.
+  A URL carrying `relay` also opens on the MoQ transport rather than the
+  default. Without it, MoQ behaves exactly as before.
+
 ## [1.0.5] - 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,17 @@ pip install pipecat-ai-prebuilt
 
 ### Added
 
-- MoQ direct-mode support. A bot run with `--moq-direct` is already on the
-  relay before anyone opens the client, so there is no `/start` to ask where
-  to meet it. The client reads the session from the page URL instead —
-  `relay`, `ns`, `botId`, and `clientId`, as the Pipecat runner prints them —
-  and connects the transport straight from those, skipping the `/start` POST.
-  A URL carrying `relay` also opens on the MoQ transport rather than the
-  default. Without it, MoQ behaves exactly as before.
+- MoQ direct-mode support. A bot run with `--moq-direct` waits on the relay
+  rather than being started by a `/start` request, so there is nothing to ask
+  where to meet it. The client reads the relay and namespace from the page URL
+  instead — `relay`, `ns`, `botId`, and `clientId`, as the Pipecat runner
+  prints them — and connects the transport straight from those, skipping the
+  `/start` POST. A URL carrying `relay` also opens on the MoQ transport rather
+  than the default.
+- Each page load mints its own session id and hangs both broadcast paths off
+  it, so a shared direct-mode URL gives every visitor their own call instead of
+  publishing over each other. The runner starts a bot per id it sees.
+- Without `relay` in the URL, MoQ behaves exactly as before.
 
 ## [1.0.5] - 2026-07-20
 

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -16,9 +16,39 @@ import {
   TwilioSerializer,
   WebSocketTransport,
 } from "@pipecat-ai/websocket-transport";
+import type { MoqTransportOptions } from "@pipecat-ai/moq-transport";
 import { PipecatClient, RTVIEvent } from "@pipecat-ai/client-js";
 
 type TransportType = "smallwebrtc" | "daily" | "websocket" | "twilio" | "moq";
+
+/**
+ * Read a MoQ direct-mode session from the page URL.
+ *
+ * A bot run with `--moq-direct` is already on the relay before anyone opens
+ * this page, so there is no `/start` to ask where to meet it. The runner
+ * prints a URL carrying that instead: the relay to dial, the namespace to
+ * rendezvous on, and which end of the path pair each side owns.
+ *
+ * Returns null for a normal `/start` session.
+ */
+function readMoqDirectOptions(): MoqTransportOptions | null {
+  const params = new URLSearchParams(window.location.search);
+  const relayUrl = params.get("relay");
+  if (!relayUrl) return null;
+
+  const namespace = params.get("ns");
+  const botId = params.get("botId");
+  const clientId = params.get("clientId");
+  return {
+    relayUrl,
+    ...(namespace ? { namespace } : {}),
+    // The bot publishes its own broadcast as the response and reads the
+    // peer's as the request, so we take the opposite pair. Worth passing
+    // explicitly: the transport still defaults to the older bot0/client0.
+    ...(botId ? { botId } : {}),
+    ...(clientId ? { clientId } : {}),
+  };
+}
 
 const TRANSPORT_OPTIONS: { value: TransportType; label: string }[] = [
   { value: "smallwebrtc", label: "SmallWebRTC" },
@@ -94,7 +124,13 @@ function getTransportProps(
         },
         startBotResponseTransformer: websocketResponseTransformer,
       };
-    case "moq":
+    case "moq": {
+      const directOptions = readMoqDirectOptions();
+      if (directOptions) {
+        // Leaving startBotParams unset is what skips the /start POST: the
+        // base connects the transport straight from these options.
+        return { transportOptions: directOptions };
+      }
       return {
         startBotParams: {
           endpoint: `/start`,
@@ -103,6 +139,7 @@ function getTransportProps(
           },
         },
       };
+    }
   }
 }
 
@@ -138,8 +175,11 @@ function TransportSelect({ value, onValueChange }: TransportSelectProps) {
 }
 
 function Home() {
-  const [transportType, setTransportType] =
-    useState<TransportType>("smallwebrtc");
+  // A direct-mode URL names the session to join, so open on that transport
+  // instead of making the visitor pick it out of the selector.
+  const [transportType, setTransportType] = useState<TransportType>(() =>
+    readMoqDirectOptions() ? "moq" : "smallwebrtc",
+  );
   const { startBotParams, transportOptions, startBotResponseTransformer } =
     getTransportProps(transportType);
 

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -36,7 +36,12 @@ function readMoqDirectOptions(): MoqTransportOptions | null {
   const relayUrl = params.get("relay");
   if (!relayUrl) return null;
 
-  const namespace = params.get("ns");
+  // Empty rather than the transport's built-in default, so an unscoped
+  // URL puts the call at the relay root instead of silently joining the
+  // shared `pipecat` namespace. The session id below is what keeps one
+  // caller's broadcasts off another's.
+  const namespace = params.get("ns") ?? "";
+
   // The bot publishes its own broadcast as the response and reads the
   // peer's as the request, so we take the opposite pair. Worth naming
   // explicitly: the transport still defaults to the older bot0/client0.
@@ -50,7 +55,7 @@ function readMoqDirectOptions(): MoqTransportOptions | null {
   const session = crypto.randomUUID();
   return {
     relayUrl,
-    ...(namespace ? { namespace } : {}),
+    namespace,
     botId: `${botId}/${session}`,
     clientId: `${clientId}/${session}`,
   };

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -37,16 +37,22 @@ function readMoqDirectOptions(): MoqTransportOptions | null {
   if (!relayUrl) return null;
 
   const namespace = params.get("ns");
-  const botId = params.get("botId");
-  const clientId = params.get("clientId");
+  // The bot publishes its own broadcast as the response and reads the
+  // peer's as the request, so we take the opposite pair. Worth naming
+  // explicitly: the transport still defaults to the older bot0/client0.
+  const botId = params.get("botId") ?? "response";
+  const clientId = params.get("clientId") ?? "request";
+
+  // Everyone on this URL shares a namespace, so the session id is what
+  // keeps one caller's broadcasts off another's. The runner watches the
+  // request prefix and starts a bot per id it sees, which is why we mint
+  // it here rather than being told one.
+  const session = crypto.randomUUID();
   return {
     relayUrl,
     ...(namespace ? { namespace } : {}),
-    // The bot publishes its own broadcast as the response and reads the
-    // peer's as the request, so we take the opposite pair. Worth passing
-    // explicitly: the transport still defaults to the older bot0/client0.
-    ...(botId ? { botId } : {}),
-    ...(clientId ? { clientId } : {}),
+    botId: `${botId}/${session}`,
+    clientId: `${clientId}/${session}`,
   };
 }
 


### PR DESCRIPTION
## What

Adds support for MoQ **direct mode**, where the bot waits on the relay rather than being started by a `/start` request. There is no rendezvous response to ask where to meet it, so the client reads the session from the page URL instead and connects the transport straight from those values.

Depends on the Pipecat runner's `--moq-direct` flag (pipecat-ai/pipecat#5123).

## How

- `relay`, `ns`, `botId`, `clientId` are read from the query string, as the runner prints them, and passed to `MoqTransport` as constructor options. Leaving `startBotParams` unset is what skips the POST — `PipecatAppBase` connects the transport directly when no endpoint is in play, so no change was needed in `voice-ui-kit`.
- A URL carrying `relay` also opens on the MoQ transport rather than the default, since it names the session to join.
- Each page load mints its own session id and hangs both broadcast paths off it (`<client-id>/<uuid>`, `<bot-id>/<uuid>`). Everyone sharing a direct-mode URL shares a namespace, so without this the second visitor publishes over the first and neither call works. The runner watches the request prefix and starts a bot per id it sees.
- `ns` is optional and defaults to empty, putting calls at the relay root. Falling back to the transport's built-in `pipecat` namespace would quietly place an unscoped call on a path shared with everyone else who omitted it — on a public relay, both a collision and a disclosure.

Without `relay` in the URL, MoQ behaves exactly as before.

`botId`/`clientId` are passed explicitly because `@pipecat-ai/moq-transport` still defaults them to the older `bot0`/`client0` pair, while the bot now publishes its broadcast as the `response` and reads the peer's as the `request`.

## Testing

Ran against a live `--moq-direct` bot: the UI opens on MoQ from the URL, connects with **no `/start` request** (confirmed by filtering the network log), negotiates RTVI, renders the bot's greeting, and carries typed input back to the bot over the MoQ transcript track. Two browsers on one URL each get their own bot with disjoint paths. `tsc --noEmit` and `vite build` clean.

Note that a direct-mode session also needs pipecat-ai/pipecat-client-web-transports#167 — without it the client subscribes to the bot's broadcast before the bot exists and the streams are reset.

(written by Opus 5)